### PR TITLE
discord: add application command for pushing to ongcodething

### DIFF
--- a/discord/ongcodebot.py
+++ b/discord/ongcodebot.py
@@ -539,7 +539,7 @@ def main():
 
         # Get the ongcodething endpoint from credentials
         ongcodething_endpoint = bot.botargs.creds.get("ongcodething_endpoint")
-        if not codething_endpoint:
+        if not ongcodething_endpoint:
             await message_obj.edit(content="Error: ongcodething_endpoint not configured")
             return
 

--- a/discord/ongcodebot.py
+++ b/discord/ongcodebot.py
@@ -489,6 +489,36 @@ def main():
         if isinstance(error, discord.ext.commands.MissingRole):
             await ctx.respond("Permission denied", ephemeral=True)
 
+
+    # Message command for sending ongcode to Jon
+    @bot.message_command(name="Send Ongcode to Jon")
+    async def cmd_ongcode_send(
+        ctx: discord.ApplicationContext, message: discord.Message
+    ):
+        # Right channel?
+        if message.channel.id != bot.botchannel.id:
+            return
+
+        # Not me?
+        if message.author.id == bot.user.id:
+            return
+
+        if discord.utils.get(ctx.author.roles, name=bot.botargs.moderator_role):
+            is_mod = True
+        else:
+            is_mod = False
+
+        if not is_mod:
+            await ctx.respond("Permission denied", ephemeral=True)
+            return
+
+        await ctx.respond(f"{ctx.author.name}, here's the message id: {message.id}!", ephemeral=True)
+        print(ppretty(ctx))
+        print(ppretty(message))
+        print(f"ZOT: {ctx.author.id}")
+        print(f"ZOT: {message.author.id}")
+
+
     # A couple of testing things
     class MyModal(discord.ui.Modal):
         def __init__(self, *args, **kwargs) -> None:

--- a/discord/ongcodebot.py
+++ b/discord/ongcodebot.py
@@ -333,6 +333,13 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--ongcodething",
+        type=str,  # FIXME: Is there a "URL" type we can use?
+        default=None,
+        help="URL for ongcodething backend"
+    )
+
+    parser.add_argument(
         "--dbfile",
         type=Path,
         default=None,
@@ -360,7 +367,8 @@ def main():
 
     args = parse_args()
     creds = get_credentials(args.credentials_file, args.environment)
-    args.creds = creds  # Store credentials in args
+    # print(args)
+    # args.creds = creds  # Store credentials in args, can't figure out if this is stupid
 
     if args.debug_queries:
         import logging
@@ -369,21 +377,24 @@ def main():
         logger.setLevel(logging.DEBUG)
 
     if args.ongcode_guild is None:
-        args.ongcode_guild = creds.get("guild", None)
+        args.ongcode_guild = creds.get("guild")
 
     if args.ongcode_guild is None:
         log("ERROR: No guild specified and no guild in configuration")
         sys.exit(1)
 
     if args.ongcode_channel is None:
-        args.ongcode_channel = creds.get("channel", None)
+        args.ongcode_channel = creds.get("channel")
 
     if args.ongcode_channel is None:
         log("ERROR: No channel specified and no channel in configuration")
         sys.exit(1)
 
     if args.moderator_role is None:
-        args.moderator_role = creds.get("moderator_role", None)
+        args.moderator_role = creds.get("moderator_role")
+
+    if args.ongcodething is None:
+        args.ongcodething = creds.get("ongcodething")
 
     if args.dbfile is None:
         args.dbfile = Path(__file__).parent / f"ongcode_{args.environment}.db"
@@ -515,8 +526,8 @@ def main():
             return
 
         # Send initial response
-        response = await ctx.respond("Processing your request...", ephemeral=True)
-        message_obj = await response.original_message()
+        response = await ctx.respond("Sending...", ephemeral=True)
+        message_obj = await response.original_message()  # FIXME: deprecated
 
         # Check if this message is a title or ongcode
         ongcode = OngCode.get_or_none(
@@ -538,9 +549,9 @@ def main():
             body = ongcode.mainmsg_text
 
         # Get the ongcodething endpoint from credentials
-        ongcodething_endpoint = bot.botargs.creds.get("ongcodething_endpoint")
+        ongcodething_endpoint = bot.botargs.ongcodething
         if not ongcodething_endpoint:
-            await message_obj.edit(content="Error: ongcodething_endpoint not configured")
+            await message_obj.edit(content="Error: ongcodething endpoint not configured")
             return
 
         # Send to codething backend

--- a/discord/ongcodebot.py
+++ b/discord/ongcodebot.py
@@ -537,17 +537,17 @@ def main():
             title = ongcode.titlemsg_text or "Untitled"
             body = ongcode.mainmsg_text
 
-        # Get the codething endpoint from credentials
-        codething_endpoint = bot.botargs.creds.get("codething_endpoint")
+        # Get the ongcodething endpoint from credentials
+        ongcodething_endpoint = bot.botargs.creds.get("ongcodething_endpoint")
         if not codething_endpoint:
-            await message_obj.edit(content="Error: codething_endpoint not configured")
+            await message_obj.edit(content="Error: ongcodething_endpoint not configured")
             return
 
         # Send to codething backend
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.post(
-                    f"{codething_endpoint}/songs/",
+                    f"{ongcodething_endpoint}/songs/",
                     json={
                         "title": title,
                         "body": body,

--- a/discord/ongcodebot.py
+++ b/discord/ongcodebot.py
@@ -333,7 +333,7 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--ongcodething",
+        "--ongcodething-url", "--ongcodething",
         type=str,  # FIXME: Is there a "URL" type we can use?
         default=None,
         help="URL for ongcodething backend"
@@ -367,8 +367,6 @@ def main():
 
     args = parse_args()
     creds = get_credentials(args.credentials_file, args.environment)
-    # print(args)
-    # args.creds = creds  # Store credentials in args, can't figure out if this is stupid
 
     if args.debug_queries:
         import logging
@@ -393,8 +391,8 @@ def main():
     if args.moderator_role is None:
         args.moderator_role = creds.get("moderator_role")
 
-    if args.ongcodething is None:
-        args.ongcodething = creds.get("ongcodething")
+    if args.ongcodething_url is None:
+        args.ongcodething_url = creds.get("ongcodething_url")
 
     if args.dbfile is None:
         args.dbfile = Path(__file__).parent / f"ongcode_{args.environment}.db"
@@ -537,8 +535,8 @@ def main():
         body = ongcode.mainmsg_text
 
         # Get the ongcodething endpoint from credentials
-        ongcodething_endpoint = bot.botargs.ongcodething
-        if not ongcodething_endpoint:
+        ongcodething_url = bot.botargs.ongcodething_url
+        if not ongcodething_url:
             log("WARNING: ongcodething called but not configured")
             await message_obj.edit(content="Error: ongcodething endpoint not configured")
             return
@@ -547,7 +545,7 @@ def main():
         async with aiohttp.ClientSession() as session:
             try:
                 post_response = await session.post(
-                    f"{ongcodething_endpoint}/songs/",
+                    f"{ongcodething_url}/songs/",
                     json={
                         "title": title,
                         "body": body,


### PR DESCRIPTION
Adds a "Send Ongcode to Jon" application command for the ongcode bot, which sends ongcode over to the backend for ongcodething (https://github.com/alinsavix/ongcodething). Requires a `ongcodething_endpoint` entry in credentials.toml to work. 

At some point we really should convert the ongcode bot to use cogs